### PR TITLE
Update googletest to 1.8.0 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ python:
 install:
  - sudo apt-get update
  - sudo apt-get install libboost-test-dev
- - sudo apt-get install libgtest-dev
- - "cd /usr/src/gtest && sudo cmake . && sudo make && sudo cp *.a /usr/lib ; cd -"
+ - wget https://github.com/google/googletest/archive/release-1.8.0.tar.gz
+ - tar -zxvf release-1.8.0.tar.gz
+ - "cd googletest-release-1.8.0/googletest && cmake . && sudo make install; cd -"
+ - rm -rf googletest-release-1.8.0
  - pip install tox coveralls
 
 script:

--- a/tests/test_pytest_cpp.py
+++ b/tests/test_pytest_cpp.py
@@ -73,16 +73,16 @@ def test_google_failure(exes):
     assert len(failures) == 2
     colors = ('red', 'bold')
     assert failures[0].get_lines() == [
-        ('Value of: 5', colors),
-        ('Expected: 2 * 3', colors),
-        ('Which is: 6', colors),
+        ('      Expected: 2 * 3', colors),
+        ('      Which is: 6', colors),
+        ('To be equal to: 5', colors),
     ]
     assert failures[0].get_file_reference() == ('gtest.cpp', 17)
 
     assert failures[1].get_lines() == [
-        ('Value of: 15', colors),
-        ('Expected: 2 * 6', colors),
-        ('Which is: 12', colors),
+        ('      Expected: 2 * 6', colors),
+        ('      Which is: 12', colors),
+        ('To be equal to: 15', colors),
     ]
     assert failures[1].get_file_reference() == ('gtest.cpp', 18)
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,4 @@ deps=pytest
     coverage    
 commands=
     coverage run --source=pytest_cpp .pytest.py
-    py.test -n8
+    py.test -n8 tests


### PR DESCRIPTION
Follow-up of #24.

In the end it seems pytest-cpp already works with `googletest-1.8.0`. Testing with that version from now on.

cc @willsheffler