### PR TITLE
Deal with fixture init failures in boost.test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.4.4
+
+- Properly handle fixture failures in Boost.Test.
+  Thanks @fj128 for the PR.
+
 # 0.4.3
 
 - Use XML in CAPS since beginning at Boost 1.61 the parameter value is case sensitive (#29).

--- a/pytest_cpp/boost.py
+++ b/pytest_cpp/boost.py
@@ -69,6 +69,13 @@ class BoostTestFacade(object):
                                     returncode=p.returncode))
             return [failure]
 
+        if report is not None and (
+                report.startswith('Boost.Test framework internal error: ') or
+                report.startswith('Test setup error: ')):
+            # boost.test doesn't do XML output on fatal-enough errors.
+            failure = BoostTestFailure('unknown location', 0, report)
+            return [failure]
+
         results = self._parse_log(log=log)
         shutil.rmtree(temp_dir)
         if results:

--- a/tests/SConstruct
+++ b/tests/SConstruct
@@ -20,7 +20,7 @@ Export('env genv')
 
 genv.Program('gtest.cpp')
 
-for filename in ('boost_success.cpp', 'boost_failure.cpp', 'boost_error.cpp'):
+for filename in ('boost_success.cpp', 'boost_failure.cpp', 'boost_error.cpp', 'boost_fixture_setup_error.cpp'):
     env.Program(filename)
 
 SConscript('acceptance/googletest-samples/SConscript')

--- a/tests/boost_fixture_setup_error.cpp
+++ b/tests/boost_fixture_setup_error.cpp
@@ -1,0 +1,21 @@
+#include <stdexcept>
+#define BOOST_TEST_MODULE MyTest
+#include <boost/test/included/unit_test.hpp>
+
+struct InitTests {
+    InitTests() {
+        fprintf(stdout, "something on the stdout\n");
+        fflush(stdout);
+        fprintf(stderr, "something on the stderr\n");
+        fflush(stderr);
+        throw std::runtime_error("This is a global fixture init failure");
+    }
+};
+BOOST_GLOBAL_FIXTURE(InitTests);
+
+
+BOOST_AUTO_TEST_CASE( test_dummy )
+{
+    return;
+}
+

--- a/tests/test_pytest_cpp.py
+++ b/tests/test_pytest_cpp.py
@@ -140,7 +140,7 @@ def test_boost_fixture_setup_error(exes):
     failures = facade.run_test(exes.get('boost_fixture_setup_error'), '<unused>')
     assert len(failures) == 1
 
-    [fail1] = failures
+    fail1 = failures[0]
     colors = ('red', 'bold')
     assert fail1.get_lines() == [
         ('Test setup error: std::runtime_error: This is a global fixture init failure', colors)]


### PR DESCRIPTION
On sufficiently fatal errors (such as an exception thrown from a global fixture ctor) boost.test
ignores --output_format=XML and dumps the error message as is. I added an explicit check for those cases so the plugin no longer throws a weird exception from the depths of lxml due to malformed/empty xml.

(Alternatively I could check for result code 200 (aka boost::exit_exception_failure), but I'm not entirely sure that boost.test doesn't return it in some other cases, and I think that this approach is good enough)