### PR TITLE
Drop --cpp-arguments in favor of using pytest's -o option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,8 +55,9 @@ ini configuration:
 
 By default matches ``test_*`` and ``*_test`` executable files.
 
-Additional arguments to the C++ tests can be provided with the option
-``--cpp-arguments`` or with the ``cpp_arguments`` ini configuration.
+Additional arguments to the C++ tests can be provided with the
+``cpp_arguments`` ini configuration.
+
 For example:
 
 .. code-block:: ini
@@ -64,11 +65,12 @@ For example:
     [pytest]
     cpp_arguments=-v --log-dir=logs
 
-Or the same with the command line option:
+You can change this option directly in the command-line using
+pytest's ``-o`` option:
 
 .. code-block:: console
 
-    $ pytest --cpp-arguments='-v --log-dir=logs'
+    $ pytest -o cpp_arguments='-v --log-dir=logs'
 
 
 Requirements
@@ -83,7 +85,7 @@ Install
 Install using `pip <http://pip-installer.org/>`_:
 
 .. code-block:: console
-    
+
     $ pip install pytest-cpp
 
 Changelog

--- a/pytest_cpp/plugin.py
+++ b/pytest_cpp/plugin.py
@@ -25,11 +25,7 @@ def pytest_collect_file(parent, path):
     config = parent.config
     masks = config.getini('cpp_files') or DEFAULT_MASKS
 
-    test_args = config.getoption(_ARGUMENTS)
-    if test_args:
-        test_args = test_args.split()
-    else:
-        test_args = config.getini(_ARGUMENTS) or ()
+    test_args = config.getini(_ARGUMENTS) or ()
 
     if not parent.session.isinitpath(path):
         for pat in masks:
@@ -50,9 +46,6 @@ def pytest_addoption(parser):
                   type='args',
                   default='',
                   help='Additional arguments for test executables')
-
-    group = parser.getgroup('cpp tests')
-    group.addoption('--cpp-arguments', help='Additional test arguments')
 
 
 class CppFile(pytest.File):

--- a/tests/test_pytest_cpp.py
+++ b/tests/test_pytest_cpp.py
@@ -245,7 +245,7 @@ def test_cpp_failure_repr(dummy_failure):
 def test_cpp_files_option(testdir, exes):
     exes.get('boost_success')
     exes.get('gtest')
-    
+
     result = testdir.inline_run('--collect-only')
     reps = result.getreports()
     assert len(reps) == 1
@@ -290,7 +290,7 @@ def test_google_one_argument_via_option(testdir, exes):
     result = testdir.inline_run(exes.get('gtest_args'),
                                 '-k',
                                 'ArgsTest.one_argument',
-                                '--cpp-arguments', 'argument1')
+                                '-o', 'cpp_arguments=argument1')
     assert_outcomes(result,
                     [('ArgsTest.one_argument', 'passed')])
 
@@ -299,8 +299,7 @@ def test_google_two_arguments_via_option(testdir, exes):
     result = testdir.inline_run(exes.get('gtest_args'),
                                 '-k',
                                 'ArgsTest.two_arguments',
-                                '--cpp-arguments',
-                                'argument1 argument2')
+                                '-o', 'cpp_arguments=argument1 argument2')
     assert_outcomes(result,
                     [('ArgsTest.two_arguments', 'passed')])
 
@@ -313,7 +312,7 @@ def test_argument_option_priority(testdir, exes):
     result = testdir.inline_run(exes.get('gtest_args'),
                                 '-k',
                                 'ArgsTest.one_argument',
-                                '--cpp-arguments', 'argument1')
+                                '-o', 'cpp_arguments=argument1')
     assert_outcomes(result,
                     [('ArgsTest.one_argument', 'passed')])
 
@@ -342,15 +341,14 @@ def test_boost_two_arguments(testdir, exes):
 
 def test_boost_one_argument_via_option(testdir, exes):
     result = testdir.inline_run(exes.get('boost_one_argument'),
-                                '--cpp-arguments',
-                                'argument1')
+                                '-o', 'cpp_arguments=argument1')
     assert_outcomes(result,
                     [('boost_one_argument', 'passed')])
 
 
 def test_boost_two_arguments_via_option(testdir, exes):
     result = testdir.inline_run(exes.get('boost_two_arguments'),
-                                '--cpp-arguments=argument1 argument2')
+                                '-o', 'cpp_arguments=argument1 argument2')
     assert_outcomes(result,
                     [('boost_two_arguments', 'passed')])
 


### PR DESCRIPTION
Using -o we don't need an additional command-line option.

@elkin what do you think? Sorry, I only realized we could use `-o` after I merged your PR.

Follow up to #36. 