### PR TITLE
#39 cpp_ignore_py_files option

### DIFF
--- a/tests/SConstruct
+++ b/tests/SConstruct
@@ -9,6 +9,7 @@ else:
     LIBS = ['pthread']
 
 env = Environment(
+    CXX=os.environ.get('CXX'),
     CPPPATH=os.environ.get('INCLUDE'),
     CCFLAGS=CCFLAGS,
     LIBPATH=os.environ.get('LIBPATH'),

--- a/tests/acceptance/boosttest-samples/unit_test_example_09_1.cpp
+++ b/tests/acceptance/boosttest-samples/unit_test_example_09_1.cpp
@@ -20,7 +20,7 @@ struct MyConfig {
 };
 
 // structure MyConfig is used as a global fixture - it's invoked pre and post any testing is performed
-BOOST_GLOBAL_FIXTURE( MyConfig )
+BOOST_GLOBAL_FIXTURE( MyConfig );
 
 //____________________________________________________________________________//
 

--- a/tests/acceptance/boosttest-samples/unit_test_example_09_2.cpp
+++ b/tests/acceptance/boosttest-samples/unit_test_example_09_2.cpp
@@ -21,7 +21,7 @@ struct MyConfig2 {
 };
 
 // structure MyConfig2 is used as a global fixture. You could have any number of global fxtures
-BOOST_GLOBAL_FIXTURE( MyConfig2 )
+BOOST_GLOBAL_FIXTURE( MyConfig2 );
 
 //____________________________________________________________________________//
 

--- a/tests/test_pytest_cpp.py
+++ b/tests/test_pytest_cpp.py
@@ -256,8 +256,9 @@ def test_cpp_files_option(testdir, exes):
         cpp_files = gtest* boost*
     ''')
     result = testdir.inline_run('--collect-only')
-    assert len(result.matchreport(exes.exe_name('boost_success')).result) == 1
-    assert len(result.matchreport(exes.exe_name('gtest')).result) == 4
+    print(result)
+    assert len(result.matchreport(exes.exe_name('boost_success'), when='collect').result) == 1
+    assert len(result.matchreport(exes.exe_name('gtest'), when='collect').result) == 4
 
 
 def test_google_one_argument(testdir, exes):


### PR DESCRIPTION
This adds a new option, "cpp_ignore_py_files", that is True by default, and prevents the plugin from trying to execute ordinary pytest modules that are marked as executable, to see if they are secretly boost or google test modules. Implements #39