### PR TITLE
add cpp_ignore_py_files option (enabled by default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 1.2.0
 
 - `pytest-cpp` no longer supports Python 3.4.
+- New `cpp_ignore_py_files` option that makes the plugin ignore `*.py` files even if they
+  would otherwise match the `cpp_files` option (defaults to `True`).
 
 # 1.1.0
 

--- a/README.rst
+++ b/README.rst
@@ -45,27 +45,34 @@ Once installed, when py.test runs it will search and run tests
 found in executable files, detecting if the suites are
 Google or Boost tests automatically.
 
+Configuration Options
+~~~~~~~~~~~~~~~~~~~~~
+
+**cpp_files**
+
 You can configure which files are tested for suites by using the ``cpp_files``
-ini configuration:
+ini configuration option:
 
 .. code-block:: ini
 
     [pytest]
-    cpp_files=test_suite*
+    cpp_files = test_suite*
 
 By default matches ``test_*`` and ``*_test`` executable files.
 
-Additional arguments to the C++ tests can be provided with the
-``cpp_arguments`` ini configuration.
+**cpp_arguments**
 
 *New in version 1.1*.
+
+Arguments to the C++ tests can be provided with the
+``cpp_arguments`` ini configuration option.
 
 For example:
 
 .. code-block:: ini
 
     [pytest]
-    cpp_arguments=-v --log-dir=logs
+    cpp_arguments =-v --log-dir=logs
 
 You can change this option directly in the command-line using
 pytest's ``-o`` option:
@@ -74,12 +81,19 @@ pytest's ``-o`` option:
 
     $ pytest -o cpp_arguments='-v --log-dir=logs'
 
+**cpp_ignore_py_files**
 
-Requirements
-============
+*New in version 1.2*.
 
-* Python 2.7+, Python 3.4+
-* pytest
+This option defaults to ``True`` and configures the plugin to ignore ``*.py`` files that
+would otherwise match the ``cpp_files`` option.
+
+Set it to ``False`` if you have C++ executable files that end with the ``*.py`` extension.
+
+.. code-block:: ini
+
+    [pytest]
+    cpp_ignore_py_files = False
 
 Install
 =======

--- a/tests/SConstruct
+++ b/tests/SConstruct
@@ -8,13 +8,16 @@ else:
     CCFLAGS = ''
     LIBS = ['pthread']
 
-env = Environment(
-    CXX=os.environ.get('CXX'),
-    CPPPATH=os.environ.get('INCLUDE'),
-    CCFLAGS=CCFLAGS,
-    LIBPATH=os.environ.get('LIBPATH'),
-    LIBS=LIBS,
-)
+kwargs = {
+    'CPPPATH': os.environ.get('INCLUDE'),
+    'CCFLAGS': CCFLAGS,
+    'LIBPATH': os.environ.get('LIBPATH'),
+    'LIBS': LIBS,
+}
+if 'CXX' in os.environ:
+    kwargs['CXX'] = os.environ['CXX']
+    
+env = Environment(**kwargs)
 genv = env.Clone(LIBS=['gtest'] + LIBS)
 
 Export('env genv')

--- a/tests/SConstruct
+++ b/tests/SConstruct
@@ -9,6 +9,7 @@ else:
     LIBS = ['pthread']
 
 env = Environment(
+    CXX=os.environ.get('CXX'),
     CPPPATH=os.environ.get('INCLUDE'),
     CCFLAGS=CCFLAGS,
     LIBPATH=os.environ.get('LIBPATH'),

--- a/tests/test_pytest_cpp.py
+++ b/tests/test_pytest_cpp.py
@@ -271,24 +271,18 @@ def test_cpp_ignore_py_files(testdir, exes):
         cpp_files = cpptest_*
     ''')
 
-    result = testdir.inline_run('--collect-only')
-    reps = result.getreports()
-    print(reps)
-    assert len(reps) == 1
-    assert reps[0].result == []
+    result = testdir.runpytest('--collect-only')
+    result.stdout.fnmatch_lines('* no tests ran *')
 
-    result = testdir.inline_run('--collect-only', '-o', 'cpp_ignore_py_files=False')
-    assert len(result.matchreport(exes.exe_name(file_name), when='collect').result) == 4
+    result = testdir.runpytest('--collect-only', '-o', 'cpp_ignore_py_files=False')
+    result.stdout.fnmatch_lines("*CppFile cpptest_success.py*")
 
     # running directly skips out machinery as well.
-    result = testdir.inline_run('--collect-only', file_name)
-    assert len(result.matchreport(exes.exe_name(file_name), when='collect').result) == 0
+    result = testdir.runpytest('--collect-only', file_name)
+    result.stdout.fnmatch_lines('*1 error in*')
 
-    result = testdir.inline_run('--collect-only', '-o', 'cpp_ignore_py_files=False', file_name)
-    # assert len(result.matchreport(exes.exe_name(file_name)).result) == 4
-    # workaround for a pytest bug
-    print([(rep.nodeid.split("::"), len(rep.result)) for rep in result.getreports()])
-    assert any(file_name in rep.nodeid.split("::") and len(rep.result) == 4 for rep in result.getreports())
+    result = testdir.runpytest('--collect-only', '-o', 'cpp_ignore_py_files=False', file_name)
+    result.stdout.fnmatch_lines("*CppFile cpptest_success.py*")
 
 
 def test_google_one_argument(testdir, exes):

--- a/tests/test_pytest_cpp.py
+++ b/tests/test_pytest_cpp.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 import subprocess
 from pytest_cpp import error
@@ -258,6 +259,36 @@ def test_cpp_files_option(testdir, exes):
         "*CppFile boost_success*",
         "*CppFile gtest*",
     ])
+
+
+# skip to avoid dealing with exes.get appending extension
+@pytest.mark.skipif(sys.platform.startswith('win'), reason='This is not a problem on Windows')
+def test_cpp_ignore_py_files(testdir, exes):
+    file_name = 'cpptest_success.py'
+    exes.get('gtest', 'cpptest_success.py')
+    testdir.makeini('''
+        [pytest]
+        cpp_files = cpptest_*
+    ''')
+
+    result = testdir.inline_run('--collect-only')
+    reps = result.getreports()
+    print(reps)
+    assert len(reps) == 1
+    assert reps[0].result == []
+
+    result = testdir.inline_run('--collect-only', '-o', 'cpp_ignore_py_files=False')
+    assert len(result.matchreport(exes.exe_name(file_name), when='collect').result) == 4
+
+    # running directly skips out machinery as well.
+    result = testdir.inline_run('--collect-only', file_name)
+    assert len(result.matchreport(exes.exe_name(file_name), when='collect').result) == 0
+
+    result = testdir.inline_run('--collect-only', '-o', 'cpp_ignore_py_files=False', file_name)
+    # assert len(result.matchreport(exes.exe_name(file_name)).result) == 4
+    # workaround for a pytest bug
+    print([(rep.nodeid.split("::"), len(rep.result)) for rep in result.getreports()])
+    assert any(file_name in rep.nodeid.split("::") and len(rep.result) == 4 for rep in result.getreports())
 
 
 def test_google_one_argument(testdir, exes):


### PR DESCRIPTION
Supersedes https://github.com/pytest-dev/pytest-cpp/pull/42