### PR TITLE
Add cpp_harness option to invoke test with a tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
 
 install:
  - sudo apt-get update
- - sudo apt-get install libboost-test-dev
+ - sudo apt-get install libboost-test-dev valgrind
  - wget https://github.com/google/googletest/archive/release-1.8.0.tar.gz
  - tar -zxvf release-1.8.0.tar.gz
  - "cd googletest-release-1.8.0/googletest && cmake . && sudo make install; cd -"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.0
+
+- New `cpp_harness` configuration option allows users to add prefix arguments when running the C++ test runner, allowing to use tools like `valgrind`. Thanks to @dajose for contributing!
+
 # 1.2.1
 
 - Remove `from_parent()`-related warnings in pytest 5.4.2+.

--- a/README.rst
+++ b/README.rst
@@ -100,8 +100,10 @@ Set it to ``False`` if you have C++ executable files that end with the ``*.py`` 
 
 **cpp_harness**
 
+*New in version 1.3*.
+
 This option allows the usage of tools that are used by invoking them on the console
-wrapping the test binary, like valgrind and memcheck
+wrapping the test binary, like valgrind and memcheck:
 
 .. code-block:: ini
 

--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,16 @@ Set it to ``False`` if you have C++ executable files that end with the ``*.py`` 
     [pytest]
     cpp_ignore_py_files = False
 
+**cpp_harness**
+
+This option allows the usage of tools that are used by invoking them on the console
+wrapping the test binary, like valgrind and memcheck
+
+.. code-block:: ini
+
+    [pytest]
+    cpp_harness = valgrind --tool=memcheck
+
 Install
 =======
 

--- a/pytest_cpp/boost.py
+++ b/pytest_cpp/boost.py
@@ -30,7 +30,9 @@ class BoostTestFacade(object):
         # inside the executable, so the test_id is a dummy placeholder :(
         return [os.path.basename(os.path.splitext(executable)[0])]
 
-    def run_test(self, executable, test_id, test_args=()):
+    def run_test(self, executable, test_id, test_args=(), harness=None):
+        harness = harness or []
+
         def read_file(name):
             try:
                 with io.open(name) as f:
@@ -41,7 +43,7 @@ class BoostTestFacade(object):
         temp_dir = tempfile.mkdtemp()
         log_xml = os.path.join(temp_dir, "log.xml")
         report_xml = os.path.join(temp_dir, "report.xml")
-        args = [
+        args = harness + [
             executable,
             "--output_format=XML",
             "--log_sink=%s" % log_xml,

--- a/pytest_cpp/google.py
+++ b/pytest_cpp/google.py
@@ -57,9 +57,10 @@ class GoogleTestFacade(object):
                 result.append(test_suite + strip_comment(line).strip())
         return result
 
-    def run_test(self, executable, test_id, test_args=()):
+    def run_test(self, executable, test_id, test_args=(), harness=None):
+        harness = harness or []
         xml_filename = self._get_temp_xml_filename()
-        args = [
+        args = harness + [
             executable,
             "--gtest_filter=" + test_id,
             "--gtest_output=xml:%s" % xml_filename,

--- a/pytest_cpp/plugin.py
+++ b/pytest_cpp/plugin.py
@@ -78,6 +78,12 @@ def pytest_addoption(parser):
         default=True,
         help='ignore *.py files that otherwise match "cpp_files" patterns',
     )
+    parser.addini(
+        "cpp_harness",
+        type="args",
+        default=(),
+        help="command that wraps the cpp binary",
+    )
 
 
 class CppFile(pytest.File):
@@ -120,7 +126,12 @@ class CppItem(pytest.Item):
         )
 
     def runtest(self):
-        failures = self.facade.run_test(str(self.fspath), self.name, self._arguments)
+        failures = self.facade.run_test(
+            str(self.fspath),
+            self.name,
+            self._arguments,
+            harness=self.config.getini("cpp_harness"),
+        )
         if failures:
             raise CppFailureError(failures)
 

--- a/tests/test_pytest_cpp.py
+++ b/tests/test_pytest_cpp.py
@@ -5,6 +5,7 @@ from pytest_cpp import error
 from pytest_cpp.boost import BoostTestFacade
 from pytest_cpp.error import CppTestFailure, CppFailureRepr
 from pytest_cpp.google import GoogleTestFacade
+from distutils.spawn import find_executable
 
 
 def assert_outcomes(result, expected_outcomes):
@@ -390,6 +391,21 @@ def test_argument_option_priority(testdir, exes):
     assert_outcomes(result, [("ArgsTest.one_argument", "passed")])
 
 
+@pytest.mark.skipif(
+    not find_executable("valgrind") or not find_executable("catchsegv"),
+    reason="Environment does not have required tools",
+)
+def test_google_cpp_harness_via_option(testdir, exes):
+    result = testdir.inline_run(
+        exes.get("gtest"),
+        "-k",
+        "FooTest.test_success",
+        "-o",
+        "cpp_harness=catchsegv valgrind --tool=memcheck",
+    )
+    assert_outcomes(result, [("FooTest.test_success", "passed")])
+
+
 def test_boost_one_argument(testdir, exes):
     testdir.makeini(
         """
@@ -426,6 +442,22 @@ def test_boost_two_arguments_via_option(testdir, exes):
         exes.get("boost_two_arguments"), "-o", "cpp_arguments=argument1 argument2"
     )
     assert_outcomes(result, [("boost_two_arguments", "passed")])
+
+
+@pytest.mark.skipif(
+    not find_executable("valgrind") or not find_executable("catchsegv"),
+    reason="Environment does not have required tools",
+)
+def test_boost_cpp_harness_via_option(testdir, exes):
+    result = testdir.inline_run(
+        exes.get("boost_success"),
+        "-s",
+        "-k",
+        "boost_success",
+        "-o",
+        "cpp_harness=catchsegv valgrind --tool=memcheck",
+    )
+    assert_outcomes(result, [("boost_success", "passed")])
 
 
 def test_passing_files_directly_in_command_line(testdir, exes):

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,10 @@ envlist = py{27,35,36,37,38,38}-pytestlatest,py38-pytest53
 [testenv]
 deps=
     pytestlatest: pytest
-    pytest53: pytest ~=5.3
+    pytestlatest: pytest-xdist
+    pytest53: pytest~=5.3
+    pytest53: pytest-xdist<2
     pytest-mock
-    pytest-xdist
     coverage
 commands=
     coverage run --source=pytest_cpp -m pytest tests


### PR DESCRIPTION
Closes #49

Probably the PR checks will fail as I am using valgrind but I did not added it to the travis worker. I did that on purpose as I am not sure what kind of test you'd like for this