### PR TITLE
Add support for GTEST_SKIP()

### DIFF
--- a/src/pytest_cpp/google.py
+++ b/src/pytest_cpp/google.py
@@ -121,7 +121,10 @@ class GoogleTestFacade(object):
                 failure_elements = test_case.findall("failure")
                 for failure_elem in failure_elements:
                     failures.append(failure_elem.text)
-                skipped = test_case.attrib["status"] == "notrun" or test_case.attrib.get("result", None) == "skipped"
+                skipped = (
+                    test_case.attrib["status"] == "notrun"
+                    or test_case.attrib.get("result", None) == "skipped"
+                )
                 result.append((test_suite_name + "." + test_name, failures, skipped))
 
         return result

--- a/src/pytest_cpp/google.py
+++ b/src/pytest_cpp/google.py
@@ -121,7 +121,7 @@ class GoogleTestFacade(object):
                 failure_elements = test_case.findall("failure")
                 for failure_elem in failure_elements:
                     failures.append(failure_elem.text)
-                skipped = test_case.attrib["status"] == "notrun" or test_case.attrib["result"] == "skipped"
+                skipped = test_case.attrib["status"] == "notrun" or test_case.attrib.get("result", None) == "skipped"
                 result.append((test_suite_name + "." + test_name, failures, skipped))
 
         return result

--- a/src/pytest_cpp/google.py
+++ b/src/pytest_cpp/google.py
@@ -121,7 +121,7 @@ class GoogleTestFacade(object):
                 failure_elements = test_case.findall("failure")
                 for failure_elem in failure_elements:
                     failures.append(failure_elem.text)
-                skipped = test_case.attrib["status"] == "notrun"
+                skipped = test_case.attrib["status"] == "notrun" or test_case.attrib["result"] == "skipped"
                 result.append((test_suite_name + "." + test_name, failures, skipped))
 
         return result


### PR DESCRIPTION
This adds support for the `GTEST_SKIP()` macro, which allows to skip a GTest dynamically, without having to modify its name with `DISABLED_`