### PR TITLE
Include skipped message when using GTEST_SKIP macro

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gtest_ver: [ "1.8.0" ]
+        gtest_ver: [ "1.11.0" ]
 
     steps:
       - uses: actions/checkout@v1
@@ -22,8 +22,10 @@ jobs:
         run: |
           wget https://github.com/google/googletest/archive/release-${{ matrix.gtest_ver }}.tar.gz
           tar -zxvf release-${{ matrix.gtest_ver }}.tar.gz
-          cd googletest-release-${{ matrix.gtest_ver }}/googletest
-          cmake .
+          cd googletest-release-${{ matrix.gtest_ver }}
+          mkdir build 
+          cd build
+          cmake ..
           sudo make install
       - name: Install Boost.Test
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           wget https://github.com/google/googletest/archive/release-${{ matrix.gtest_ver }}.tar.gz
           tar -zxvf release-${{ matrix.gtest_ver }}.tar.gz
           cd googletest-release-${{ matrix.gtest_ver }}
-          mkdir build 
+          mkdir build
           cd build
           cmake ..
           sudo make install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.0
+
+- Added support for `GTEST_SKIP()` skipped message from Google Test 1.11.
+
 # 2.0.0
 
 - `pytest-cpp` now supports [Catch2](https://github.com/catchorg/Catch2). Many thanks to [@salim-runsafe](https://github.com/salim-runsafe) for the contribution.

--- a/src/pytest_cpp/google.py
+++ b/src/pytest_cpp/google.py
@@ -98,7 +98,7 @@ class GoogleTestFacade(object):
                 if failures:
                     return [GoogleTestFailure(x) for x in failures], output
                 elif skipped:
-                    pytest.skip()
+                    [pytest.skip(x) for x in skipped]
                 else:
                     return None, output
 
@@ -121,11 +121,21 @@ class GoogleTestFacade(object):
                 failure_elements = test_case.findall("failure")
                 for failure_elem in failure_elements:
                     failures.append(failure_elem.text)
-                skipped = (
-                    test_case.attrib["status"] == "notrun"
-                    or test_case.attrib.get("result", None) == "skipped"
-                )
-                result.append((test_suite_name + "." + test_name, failures, skipped))
+                skippeds = []
+                if test_case.attrib["result"] == "skipped":
+                    # In gtest 1.11 a skipped message was added to
+                    # the output file
+                    skipped_elements = test_case.findall("skipped")
+                    for skipped_elem in skipped_elements:
+                        skippeds.append(skipped_elem.text)
+                    # In gtest 1.10 the skipped message is not dump,
+                    # so if no skipped message was found just
+                    # append a "skipped" keyword
+                    if not skipped_elements:
+                        skippeds.append("Skipped")
+                if test_case.attrib["status"] == "notrun":
+                    skippeds.append("Disabled")
+                result.append((test_suite_name + "." + test_name, failures, skippeds))
 
         return result
 

--- a/src/pytest_cpp/google.py
+++ b/src/pytest_cpp/google.py
@@ -98,7 +98,7 @@ class GoogleTestFacade(object):
                 if failures:
                     return [GoogleTestFailure(x) for x in failures], output
                 elif skipped:
-                    [pytest.skip(x) for x in skipped]
+                    pytest.skip("\n".join(skipped))
                 else:
                     return None, output
 

--- a/tests/acceptance/googletest-samples/prime_tables.h
+++ b/tests/acceptance/googletest-samples/prime_tables.h
@@ -26,16 +26,15 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Author: wan@google.com (Zhanyong Wan)
-// Author: vladl@google.com (Vlad Losev)
+
+
 
 // This provides interface PrimeTable that determines whether a number is a
 // prime and determines a next prime number. This interface is used
 // in Google Test samples demonstrating use of parameterized tests.
 
-#ifndef GTEST_SAMPLES_PRIME_TABLES_H_
-#define GTEST_SAMPLES_PRIME_TABLES_H_
+#ifndef GOOGLETEST_SAMPLES_PRIME_TABLES_H_
+#define GOOGLETEST_SAMPLES_PRIME_TABLES_H_
 
 #include <algorithm>
 
@@ -44,7 +43,7 @@ class PrimeTable {
  public:
   virtual ~PrimeTable() {}
 
-  // Returns true iff n is a prime number.
+  // Returns true if and only if n is a prime number.
   virtual bool IsPrime(int n) const = 0;
 
   // Returns the smallest prime number greater than p; or returns -1
@@ -55,7 +54,7 @@ class PrimeTable {
 // Implementation #1 calculates the primes on-the-fly.
 class OnTheFlyPrimeTable : public PrimeTable {
  public:
-  virtual bool IsPrime(int n) const {
+  bool IsPrime(int n) const override {
     if (n <= 1) return false;
 
     for (int i = 2; i*i <= n; i++) {
@@ -66,12 +65,12 @@ class OnTheFlyPrimeTable : public PrimeTable {
     return true;
   }
 
-  virtual int GetNextPrime(int p) const {
-    for (int n = p + 1; n > 0; n++) {
+  int GetNextPrime(int p) const override {
+    if (p < 0) return -1;
+
+    for (int n = p + 1;; n++) {
       if (IsPrime(n)) return n;
     }
-
-    return -1;
   }
 };
 
@@ -84,13 +83,13 @@ class PreCalculatedPrimeTable : public PrimeTable {
       : is_prime_size_(max + 1), is_prime_(new bool[max + 1]) {
     CalculatePrimesUpTo(max);
   }
-  virtual ~PreCalculatedPrimeTable() { delete[] is_prime_; }
+  ~PreCalculatedPrimeTable() override { delete[] is_prime_; }
 
-  virtual bool IsPrime(int n) const {
+  bool IsPrime(int n) const override {
     return 0 <= n && n < is_prime_size_ && is_prime_[n];
   }
 
-  virtual int GetNextPrime(int p) const {
+  int GetNextPrime(int p) const override {
     for (int n = p + 1; n < is_prime_size_; n++) {
       if (is_prime_[n]) return n;
     }
@@ -103,11 +102,15 @@ class PreCalculatedPrimeTable : public PrimeTable {
     ::std::fill(is_prime_, is_prime_ + is_prime_size_, true);
     is_prime_[0] = is_prime_[1] = false;
 
-    for (int i = 2; i <= max; i++) {
+    // Checks every candidate for prime number (we know that 2 is the only even
+    // prime).
+    for (int i = 2; i*i <= max; i += i%2+1) {
       if (!is_prime_[i]) continue;
 
       // Marks all multiples of i (except i itself) as non-prime.
-      for (int j = 2*i; j <= max; j += i) {
+      // We are starting here from i-th multiplier, because all smaller
+      // complex numbers were already marked.
+      for (int j = i*i; j <= max; j += i) {
         is_prime_[j] = false;
       }
     }
@@ -120,4 +123,4 @@ class PreCalculatedPrimeTable : public PrimeTable {
   void operator=(const PreCalculatedPrimeTable& rhs);
 };
 
-#endif  // GTEST_SAMPLES_PRIME_TABLES_H_
+#endif  // GOOGLETEST_SAMPLES_PRIME_TABLES_H_

--- a/tests/acceptance/googletest-samples/sample1.cc
+++ b/tests/acceptance/googletest-samples/sample1.cc
@@ -28,8 +28,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // A sample program demonstrating using Google C++ testing framework.
-//
-// Author: wan@google.com (Zhanyong Wan)
 
 #include "sample1.h"
 
@@ -43,7 +41,7 @@ int Factorial(int n) {
   return result;
 }
 
-// Returns true iff n is a prime number.
+// Returns true if and only if n is a prime number.
 bool IsPrime(int n) {
   // Trivial case 1: small numbers
   if (n <= 1) return false;
@@ -55,7 +53,7 @@ bool IsPrime(int n) {
 
   // Try to divide n by every odd number i, starting from 3
   for (int i = 3; ; i += 2) {
-    // We only have to try i up to the squre root of n
+    // We only have to try i up to the square root of n
     if (i > n/i) break;
 
     // Now, we have i <= n/i < n.

--- a/tests/acceptance/googletest-samples/sample1.h
+++ b/tests/acceptance/googletest-samples/sample1.h
@@ -28,16 +28,14 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // A sample program demonstrating using Google C++ testing framework.
-//
-// Author: wan@google.com (Zhanyong Wan)
 
-#ifndef GTEST_SAMPLES_SAMPLE1_H_
-#define GTEST_SAMPLES_SAMPLE1_H_
+#ifndef GOOGLETEST_SAMPLES_SAMPLE1_H_
+#define GOOGLETEST_SAMPLES_SAMPLE1_H_
 
 // Returns n! (the factorial of n).  For negative n, n! is defined to be 1.
 int Factorial(int n);
 
-// Returns true iff n is a prime number.
+// Returns true if and only if n is a prime number.
 bool IsPrime(int n);
 
-#endif  // GTEST_SAMPLES_SAMPLE1_H_
+#endif  // GOOGLETEST_SAMPLES_SAMPLE1_H_

--- a/tests/acceptance/googletest-samples/sample10_unittest.cc
+++ b/tests/acceptance/googletest-samples/sample10_unittest.cc
@@ -25,8 +25,7 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Author: vladl@google.com (Vlad Losev)
+
 
 // This sample shows how to use Google Test listener API to implement
 // a primitive leak checker.
@@ -35,18 +34,15 @@
 #include <stdlib.h>
 
 #include "gtest/gtest.h"
-
 using ::testing::EmptyTestEventListener;
 using ::testing::InitGoogleTest;
 using ::testing::Test;
-using ::testing::TestCase;
 using ::testing::TestEventListeners;
 using ::testing::TestInfo;
 using ::testing::TestPartResult;
 using ::testing::UnitTest;
 
 namespace {
-
 // We will track memory used by this class.
 class Water {
  public:
@@ -78,12 +74,12 @@ int Water::allocated_ = 0;
 class LeakChecker : public EmptyTestEventListener {
  private:
   // Called before a test starts.
-  virtual void OnTestStart(const TestInfo& /* test_info */) {
+  void OnTestStart(const TestInfo& /* test_info */) override {
     initially_allocated_ = Water::allocated();
   }
 
   // Called after a test ends.
-  virtual void OnTestEnd(const TestInfo& /* test_info */) {
+  void OnTestEnd(const TestInfo& /* test_info */) override {
     int difference = Water::allocated() - initially_allocated_;
 
     // You can generate a failure in any event handler except
@@ -104,9 +100,8 @@ TEST(ListenersTest, DoesNotLeak) {
 // specified.
 TEST(ListenersTest, LeaksWater) {
   Water* water = new Water;
-  EXPECT_TRUE(water != NULL);
+  EXPECT_TRUE(water != nullptr);
 }
-
 }  // namespace
 
 int main(int argc, char **argv) {

--- a/tests/acceptance/googletest-samples/sample1_unittest.cc
+++ b/tests/acceptance/googletest-samples/sample1_unittest.cc
@@ -28,9 +28,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // A sample program demonstrating using Google C++ testing framework.
-//
-// Author: wan@google.com (Zhanyong Wan)
-
 
 // This sample shows how to write a simple unit test for a function,
 // using Google C++ testing framework.
@@ -46,7 +43,7 @@
 #include <limits.h>
 #include "sample1.h"
 #include "gtest/gtest.h"
-
+namespace {
 
 // Step 2. Use the TEST macro to define your tests.
 //
@@ -139,6 +136,7 @@ TEST(IsPrimeTest, Positive) {
   EXPECT_FALSE(IsPrime(6));
   EXPECT_TRUE(IsPrime(23));
 }
+}  // namespace
 
 // Step 3. Call RUN_ALL_TESTS() in main().
 //

--- a/tests/acceptance/googletest-samples/sample2.cc
+++ b/tests/acceptance/googletest-samples/sample2.cc
@@ -28,8 +28,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // A sample program demonstrating using Google C++ testing framework.
-//
-// Author: wan@google.com (Zhanyong Wan)
 
 #include "sample2.h"
 
@@ -37,7 +35,7 @@
 
 // Clones a 0-terminated C string, allocating memory using new.
 const char* MyString::CloneCString(const char* a_c_string) {
-  if (a_c_string == NULL) return NULL;
+  if (a_c_string == nullptr) return nullptr;
 
   const size_t len = strlen(a_c_string);
   char* const clone = new char[ len + 1 ];

--- a/tests/acceptance/googletest-samples/sample2.h
+++ b/tests/acceptance/googletest-samples/sample2.h
@@ -28,11 +28,9 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // A sample program demonstrating using Google C++ testing framework.
-//
-// Author: wan@google.com (Zhanyong Wan)
 
-#ifndef GTEST_SAMPLES_SAMPLE2_H_
-#define GTEST_SAMPLES_SAMPLE2_H_
+#ifndef GOOGLETEST_SAMPLES_SAMPLE2_H_
+#define GOOGLETEST_SAMPLES_SAMPLE2_H_
 
 #include <string.h>
 
@@ -52,15 +50,15 @@ class MyString {
   // C'tors
 
   // The default c'tor constructs a NULL string.
-  MyString() : c_string_(NULL) {}
+  MyString() : c_string_(nullptr) {}
 
   // Constructs a MyString by cloning a 0-terminated C string.
-  explicit MyString(const char* a_c_string) : c_string_(NULL) {
+  explicit MyString(const char* a_c_string) : c_string_(nullptr) {
     Set(a_c_string);
   }
 
   // Copy c'tor
-  MyString(const MyString& string) : c_string_(NULL) {
+  MyString(const MyString& string) : c_string_(nullptr) {
     Set(string.c_string_);
   }
 
@@ -73,13 +71,10 @@ class MyString {
   // Gets the 0-terminated C string this MyString object represents.
   const char* c_string() const { return c_string_; }
 
-  size_t Length() const {
-    return c_string_ == NULL ? 0 : strlen(c_string_);
-  }
+  size_t Length() const { return c_string_ == nullptr ? 0 : strlen(c_string_); }
 
   // Sets the 0-terminated C string this MyString object represents.
   void Set(const char* c_string);
 };
 
-
-#endif  // GTEST_SAMPLES_SAMPLE2_H_
+#endif  // GOOGLETEST_SAMPLES_SAMPLE2_H_

--- a/tests/acceptance/googletest-samples/sample2_unittest.cc
+++ b/tests/acceptance/googletest-samples/sample2_unittest.cc
@@ -28,9 +28,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // A sample program demonstrating using Google C++ testing framework.
-//
-// Author: wan@google.com (Zhanyong Wan)
-
 
 // This sample shows how to write a more complex unit test for a class
 // that has multiple member functions.
@@ -42,7 +39,7 @@
 
 #include "sample2.h"
 #include "gtest/gtest.h"
-
+namespace {
 // In this example, we test the MyString class (a simple string).
 
 // Tests the default c'tor.
@@ -69,7 +66,7 @@ TEST(MyString, DefaultConstructor) {
   // we have to live with this fact.
   //
   // </TechnicalDetails>
-  EXPECT_STREQ(NULL, s.c_string());
+  EXPECT_STREQ(nullptr, s.c_string());
 
   EXPECT_EQ(0u, s.Length());
 }
@@ -104,6 +101,7 @@ TEST(MyString, Set) {
   EXPECT_EQ(0, strcmp(s.c_string(), kHelloString));
 
   // Can we set the MyString to NULL?
-  s.Set(NULL);
-  EXPECT_STREQ(NULL, s.c_string());
+  s.Set(nullptr);
+  EXPECT_STREQ(nullptr, s.c_string());
 }
+}  // namespace

--- a/tests/acceptance/googletest-samples/sample3-inl.h
+++ b/tests/acceptance/googletest-samples/sample3-inl.h
@@ -28,11 +28,9 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // A sample program demonstrating using Google C++ testing framework.
-//
-// Author: wan@google.com (Zhanyong Wan)
 
-#ifndef GTEST_SAMPLES_SAMPLE3_INL_H_
-#define GTEST_SAMPLES_SAMPLE3_INL_H_
+#ifndef GOOGLETEST_SAMPLES_SAMPLE3_INL_H_
+#define GOOGLETEST_SAMPLES_SAMPLE3_INL_H_
 
 #include <stddef.h>
 
@@ -60,7 +58,8 @@ class QueueNode {
  private:
   // Creates a node with a given element value.  The next pointer is
   // set to NULL.
-  explicit QueueNode(const E& an_element) : element_(an_element), next_(NULL) {}
+  explicit QueueNode(const E& an_element)
+      : element_(an_element), next_(nullptr) {}
 
   // We disable the default assignment operator and copy c'tor.
   const QueueNode& operator = (const QueueNode&);
@@ -74,7 +73,7 @@ template <typename E>  // E is the element type.
 class Queue {
  public:
   // Creates an empty queue.
-  Queue() : head_(NULL), last_(NULL), size_(0) {}
+  Queue() : head_(nullptr), last_(nullptr), size_(0) {}
 
   // D'tor.  Clears the queue.
   ~Queue() { Clear(); }
@@ -88,12 +87,12 @@ class Queue {
       for (; ;) {
         delete node;
         node = next;
-        if (node == NULL) break;
+        if (node == nullptr) break;
         next = node->next();
       }
 
       // 2. Resets the member variables.
-      head_ = last_ = NULL;
+      head_ = last_ = nullptr;
       size_ = 0;
     }
   }
@@ -130,14 +129,14 @@ class Queue {
   // the queue is empty.
   E* Dequeue() {
     if (size_ == 0) {
-      return NULL;
+      return nullptr;
     }
 
     const QueueNode<E>* const old_head = head_;
     head_ = head_->next_;
     size_--;
     if (size_ == 0) {
-      last_ = NULL;
+      last_ = nullptr;
     }
 
     E* element = new E(old_head->element());
@@ -152,7 +151,8 @@ class Queue {
   template <typename F>
   Queue* Map(F function) const {
     Queue* new_queue = new Queue();
-    for (const QueueNode<E>* node = head_; node != NULL; node = node->next_) {
+    for (const QueueNode<E>* node = head_; node != nullptr;
+         node = node->next_) {
       new_queue->Enqueue(function(node->element()));
     }
 
@@ -169,4 +169,4 @@ class Queue {
   const Queue& operator = (const Queue&);
 };
 
-#endif  // GTEST_SAMPLES_SAMPLE3_INL_H_
+#endif  // GOOGLETEST_SAMPLES_SAMPLE3_INL_H_

--- a/tests/acceptance/googletest-samples/sample3_unittest.cc
+++ b/tests/acceptance/googletest-samples/sample3_unittest.cc
@@ -28,9 +28,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // A sample program demonstrating using Google C++ testing framework.
-//
-// Author: wan@google.com (Zhanyong Wan)
-
 
 // In this example, we use a more advanced feature of Google Test called
 // test fixture.
@@ -65,16 +62,16 @@
 
 #include "sample3-inl.h"
 #include "gtest/gtest.h"
-
+namespace {
 // To use a test fixture, derive a class from testing::Test.
-class QueueTest : public testing::Test {
+class QueueTestSmpl3 : public testing::Test {
  protected:  // You should make the members protected s.t. they can be
              // accessed from sub-classes.
 
   // virtual void SetUp() will be called before each test is run.  You
-  // should define it if you need to initialize the varaibles.
+  // should define it if you need to initialize the variables.
   // Otherwise, this can be skipped.
-  virtual void SetUp() {
+  void SetUp() override {
     q1_.Enqueue(1);
     q2_.Enqueue(2);
     q2_.Enqueue(3);
@@ -102,8 +99,8 @@ class QueueTest : public testing::Test {
     ASSERT_EQ(q->Size(), new_q->Size());
 
     // Verifies the relationship between the elements of the two queues.
-    for ( const QueueNode<int> * n1 = q->Head(), * n2 = new_q->Head();
-          n1 != NULL; n1 = n1->next(), n2 = n2->next() ) {
+    for (const QueueNode<int>*n1 = q->Head(), *n2 = new_q->Head();
+         n1 != nullptr; n1 = n1->next(), n2 = n2->next()) {
       EXPECT_EQ(2 * n1->element(), n2->element());
     }
 
@@ -120,32 +117,33 @@ class QueueTest : public testing::Test {
 // instead of TEST.
 
 // Tests the default c'tor.
-TEST_F(QueueTest, DefaultConstructor) {
+TEST_F(QueueTestSmpl3, DefaultConstructor) {
   // You can access data in the test fixture here.
   EXPECT_EQ(0u, q0_.Size());
 }
 
 // Tests Dequeue().
-TEST_F(QueueTest, Dequeue) {
+TEST_F(QueueTestSmpl3, Dequeue) {
   int * n = q0_.Dequeue();
-  EXPECT_TRUE(n == NULL);
+  EXPECT_TRUE(n == nullptr);
 
   n = q1_.Dequeue();
-  ASSERT_TRUE(n != NULL);
+  ASSERT_TRUE(n != nullptr);
   EXPECT_EQ(1, *n);
   EXPECT_EQ(0u, q1_.Size());
   delete n;
 
   n = q2_.Dequeue();
-  ASSERT_TRUE(n != NULL);
+  ASSERT_TRUE(n != nullptr);
   EXPECT_EQ(2, *n);
   EXPECT_EQ(1u, q2_.Size());
   delete n;
 }
 
 // Tests the Queue::Map() function.
-TEST_F(QueueTest, Map) {
+TEST_F(QueueTestSmpl3, Map) {
   MapTester(&q0_);
   MapTester(&q1_);
   MapTester(&q2_);
 }
+}  // namespace

--- a/tests/acceptance/googletest-samples/sample4.cc
+++ b/tests/acceptance/googletest-samples/sample4.cc
@@ -28,8 +28,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // A sample program demonstrating using Google C++ testing framework.
-//
-// Author: wan@google.com (Zhanyong Wan)
 
 #include <stdio.h>
 
@@ -38,6 +36,16 @@
 // Returns the current counter value, and increments it.
 int Counter::Increment() {
   return counter_++;
+}
+
+// Returns the current counter value, and decrements it.
+// counter can not be less than 0, return 0 in this case
+int Counter::Decrement() {
+  if (counter_ == 0) {
+    return counter_;
+  } else  {
+    return counter_--;
+  }
 }
 
 // Prints the current counter value to STDOUT.

--- a/tests/acceptance/googletest-samples/sample4.h
+++ b/tests/acceptance/googletest-samples/sample4.h
@@ -28,11 +28,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // A sample program demonstrating using Google C++ testing framework.
-//
-// Author: wan@google.com (Zhanyong Wan)
-
-#ifndef GTEST_SAMPLES_SAMPLE4_H_
-#define GTEST_SAMPLES_SAMPLE4_H_
+#ifndef GOOGLETEST_SAMPLES_SAMPLE4_H_
+#define GOOGLETEST_SAMPLES_SAMPLE4_H_
 
 // A simple monotonic counter.
 class Counter {
@@ -46,8 +43,11 @@ class Counter {
   // Returns the current counter value, and increments it.
   int Increment();
 
+  // Returns the current counter value, and decrements it.
+  int Decrement();
+
   // Prints the current counter value to STDOUT.
   void Print() const;
 };
 
-#endif  // GTEST_SAMPLES_SAMPLE4_H_
+#endif  // GOOGLETEST_SAMPLES_SAMPLE4_H_

--- a/tests/acceptance/googletest-samples/sample4_unittest.cc
+++ b/tests/acceptance/googletest-samples/sample4_unittest.cc
@@ -26,15 +26,19 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Author: wan@google.com (Zhanyong Wan)
 
-#include "gtest/gtest.h"
+
 #include "sample4.h"
+#include "gtest/gtest.h"
 
+namespace {
 // Tests the Increment() method.
+
 TEST(Counter, Increment) {
   Counter c;
+
+  // Test that counter 0 returns 0
+  EXPECT_EQ(0, c.Decrement());
 
   // EXPECT_EQ() evaluates its arguments exactly once, so they
   // can have side effects.
@@ -42,4 +46,8 @@ TEST(Counter, Increment) {
   EXPECT_EQ(0, c.Increment());
   EXPECT_EQ(1, c.Increment());
   EXPECT_EQ(2, c.Increment());
+
+  EXPECT_EQ(3, c.Decrement());
 }
+
+}  // namespace

--- a/tests/acceptance/googletest-samples/sample5_unittest.cc
+++ b/tests/acceptance/googletest-samples/sample5_unittest.cc
@@ -26,8 +26,7 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Author: wan@google.com (Zhanyong Wan)
+
 
 // This sample teaches how to reuse a test fixture in multiple test
 // cases by deriving sub-fixtures from it.
@@ -46,10 +45,10 @@
 
 #include <limits.h>
 #include <time.h>
-#include "sample3-inl.h"
 #include "gtest/gtest.h"
 #include "sample1.h"
-
+#include "sample3-inl.h"
+namespace {
 // In this sample, we want to ensure that every test finishes within
 // ~5 seconds.  If a test takes longer to run, we consider it a
 // failure.
@@ -64,15 +63,13 @@ class QuickTest : public testing::Test {
  protected:
   // Remember that SetUp() is run immediately before a test starts.
   // This is a good place to record the start time.
-  virtual void SetUp() {
-    start_time_ = time(NULL);
-  }
+  void SetUp() override { start_time_ = time(nullptr); }
 
   // TearDown() is invoked immediately after a test finishes.  Here we
   // check if the test was too slow.
-  virtual void TearDown() {
+  void TearDown() override {
     // Gets the time when the test finishes
-    const time_t end_time = time(NULL);
+    const time_t end_time = time(nullptr);
 
     // Asserts that the test took no more than ~5 seconds.  Did you
     // know that you can use assertions in SetUp() and TearDown() as
@@ -143,7 +140,7 @@ TEST_F(IntegerFunctionTest, IsPrime) {
 // stuff inside the body of the test fixture, as usual.
 class QueueTest : public QuickTest {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     // First, we need to set up the super fixture (QuickTest).
     QuickTest::SetUp();
 
@@ -177,21 +174,21 @@ TEST_F(QueueTest, DefaultConstructor) {
 // Tests Dequeue().
 TEST_F(QueueTest, Dequeue) {
   int* n = q0_.Dequeue();
-  EXPECT_TRUE(n == NULL);
+  EXPECT_TRUE(n == nullptr);
 
   n = q1_.Dequeue();
-  EXPECT_TRUE(n != NULL);
+  EXPECT_TRUE(n != nullptr);
   EXPECT_EQ(1, *n);
   EXPECT_EQ(0u, q1_.Size());
   delete n;
 
   n = q2_.Dequeue();
-  EXPECT_TRUE(n != NULL);
+  EXPECT_TRUE(n != nullptr);
   EXPECT_EQ(2, *n);
   EXPECT_EQ(1u, q2_.Size());
   delete n;
 }
-
+}  // namespace
 // If necessary, you can derive further test fixtures from a derived
 // fixture itself.  For example, you can derive another fixture from
 // QueueTest.  Google Test imposes no limit on how deep the hierarchy

--- a/tests/acceptance/googletest-samples/sample6_unittest.cc
+++ b/tests/acceptance/googletest-samples/sample6_unittest.cc
@@ -26,8 +26,7 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Author: wan@google.com (Zhanyong Wan)
+
 
 // This sample shows how to test common properties of multiple
 // implementations of the same interface (aka interface tests).
@@ -36,7 +35,7 @@
 #include "prime_tables.h"
 
 #include "gtest/gtest.h"
-
+namespace {
 // First, we define some factory functions for creating instances of
 // the implementations.  You may be able to skip this step if all your
 // implementations can be constructed the same way.
@@ -62,7 +61,7 @@ class PrimeTableTest : public testing::Test {
   // implemented by T.
   PrimeTableTest() : table_(CreatePrimeTable<T>()) {}
 
-  virtual ~PrimeTableTest() { delete table_; }
+  ~PrimeTableTest() override { delete table_; }
 
   // Note that we test an implementation via the base interface
   // instead of the actual implementation class.  This is important
@@ -74,8 +73,6 @@ class PrimeTableTest : public testing::Test {
   PrimeTable* const table_;
 };
 
-#if GTEST_HAS_TYPED_TEST
-
 using testing::Types;
 
 // Google Test offers two ways for reusing tests for different types.
@@ -85,7 +82,7 @@ using testing::Types;
 
 // To write a typed test case, first use
 //
-//   TYPED_TEST_CASE(TestCaseName, TypeList);
+//   TYPED_TEST_SUITE(TestCaseName, TypeList);
 //
 // to declare it and specify the type parameters.  As with TEST_F,
 // TestCaseName must match the test fixture name.
@@ -93,7 +90,7 @@ using testing::Types;
 // The list of types we want to test.
 typedef Types<OnTheFlyPrimeTable, PreCalculatedPrimeTable> Implementations;
 
-TYPED_TEST_CASE(PrimeTableTest, Implementations);
+TYPED_TEST_SUITE(PrimeTableTest, Implementations);
 
 // Then use TYPED_TEST(TestCaseName, TestName) to define a typed test,
 // similar to TEST_F.
@@ -132,12 +129,8 @@ TYPED_TEST(PrimeTableTest, CanGetNextPrime) {
 }
 
 // That's it!  Google Test will repeat each TYPED_TEST for each type
-// in the type list specified in TYPED_TEST_CASE.  Sit back and be
+// in the type list specified in TYPED_TEST_SUITE.  Sit back and be
 // happy that you don't have to define them multiple times.
-
-#endif  // GTEST_HAS_TYPED_TEST
-
-#if GTEST_HAS_TYPED_TEST_P
 
 using testing::Types;
 
@@ -164,7 +157,7 @@ class PrimeTableTest2 : public PrimeTableTest<T> {
 // Then, declare the test case.  The argument is the name of the test
 // fixture, and also the name of the test case (as usual).  The _P
 // suffix is for "parameterized" or "pattern".
-TYPED_TEST_CASE_P(PrimeTableTest2);
+TYPED_TEST_SUITE_P(PrimeTableTest2);
 
 // Next, use TYPED_TEST_P(TestCaseName, TestName) to define a test,
 // similar to what you do with TEST_F.
@@ -197,7 +190,7 @@ TYPED_TEST_P(PrimeTableTest2, CanGetNextPrime) {
 
 // Type-parameterized tests involve one extra step: you have to
 // enumerate the tests you defined:
-REGISTER_TYPED_TEST_CASE_P(
+REGISTER_TYPED_TEST_SUITE_P(
     PrimeTableTest2,  // The first argument is the test case name.
     // The rest of the arguments are the test names.
     ReturnsFalseForNonPrimes, ReturnsTrueForPrimes, CanGetNextPrime);
@@ -217,8 +210,8 @@ REGISTER_TYPED_TEST_CASE_P(
 // defined at the time we write the TYPED_TEST_P()s.
 typedef Types<OnTheFlyPrimeTable, PreCalculatedPrimeTable>
     PrimeTableImplementations;
-INSTANTIATE_TYPED_TEST_CASE_P(OnTheFlyAndPreCalculated,    // Instance name
-                              PrimeTableTest2,             // Test case name
-                              PrimeTableImplementations);  // Type list
+INSTANTIATE_TYPED_TEST_SUITE_P(OnTheFlyAndPreCalculated,    // Instance name
+                               PrimeTableTest2,             // Test case name
+                               PrimeTableImplementations);  // Type list
 
-#endif  // GTEST_HAS_TYPED_TEST_P
+}  // namespace

--- a/tests/acceptance/googletest-samples/sample7_unittest.cc
+++ b/tests/acceptance/googletest-samples/sample7_unittest.cc
@@ -26,8 +26,7 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Author: vladl@google.com (Vlad Losev)
+
 
 // This sample shows how to test common properties of multiple
 // implementations of an interface (aka interface tests) using
@@ -39,8 +38,7 @@
 #include "prime_tables.h"
 
 #include "gtest/gtest.h"
-
-#if GTEST_HAS_PARAM_TEST
+namespace {
 
 using ::testing::TestWithParam;
 using ::testing::Values;
@@ -65,20 +63,20 @@ PrimeTable* CreatePreCalculatedPrimeTable() {
 // can refer to the test parameter by GetParam().  In this case, the test
 // parameter is a factory function which we call in fixture's SetUp() to
 // create and store an instance of PrimeTable.
-class PrimeTableTest : public TestWithParam<CreatePrimeTableFunc*> {
+class PrimeTableTestSmpl7 : public TestWithParam<CreatePrimeTableFunc*> {
  public:
-  virtual ~PrimeTableTest() { delete table_; }
-  virtual void SetUp() { table_ = (*GetParam())(); }
-  virtual void TearDown() {
+  ~PrimeTableTestSmpl7() override { delete table_; }
+  void SetUp() override { table_ = (*GetParam())(); }
+  void TearDown() override {
     delete table_;
-    table_ = NULL;
+    table_ = nullptr;
   }
 
  protected:
   PrimeTable* table_;
 };
 
-TEST_P(PrimeTableTest, ReturnsFalseForNonPrimes) {
+TEST_P(PrimeTableTestSmpl7, ReturnsFalseForNonPrimes) {
   EXPECT_FALSE(table_->IsPrime(-5));
   EXPECT_FALSE(table_->IsPrime(0));
   EXPECT_FALSE(table_->IsPrime(1));
@@ -87,7 +85,7 @@ TEST_P(PrimeTableTest, ReturnsFalseForNonPrimes) {
   EXPECT_FALSE(table_->IsPrime(100));
 }
 
-TEST_P(PrimeTableTest, ReturnsTrueForPrimes) {
+TEST_P(PrimeTableTestSmpl7, ReturnsTrueForPrimes) {
   EXPECT_TRUE(table_->IsPrime(2));
   EXPECT_TRUE(table_->IsPrime(3));
   EXPECT_TRUE(table_->IsPrime(5));
@@ -96,7 +94,7 @@ TEST_P(PrimeTableTest, ReturnsTrueForPrimes) {
   EXPECT_TRUE(table_->IsPrime(131));
 }
 
-TEST_P(PrimeTableTest, CanGetNextPrime) {
+TEST_P(PrimeTableTestSmpl7, CanGetNextPrime) {
   EXPECT_EQ(2, table_->GetNextPrime(0));
   EXPECT_EQ(3, table_->GetNextPrime(2));
   EXPECT_EQ(5, table_->GetNextPrime(3));
@@ -112,19 +110,8 @@ TEST_P(PrimeTableTest, CanGetNextPrime) {
 //
 // Here, we instantiate our tests with a list of two PrimeTable object
 // factory functions:
-INSTANTIATE_TEST_CASE_P(
-    OnTheFlyAndPreCalculated,
-    PrimeTableTest,
-    Values(&CreateOnTheFlyPrimeTable, &CreatePreCalculatedPrimeTable<1000>));
+INSTANTIATE_TEST_SUITE_P(OnTheFlyAndPreCalculated, PrimeTableTestSmpl7,
+                         Values(&CreateOnTheFlyPrimeTable,
+                                &CreatePreCalculatedPrimeTable<1000>));
 
-#else
-
-// Google Test may not support value-parameterized tests with some
-// compilers. If we use conditional compilation to compile out all
-// code referring to the gtest_main library, MSVC linker will not link
-// that library at all and consequently complain about missing entry
-// point defined in that library (fatal error LNK1561: entry point
-// must be defined). This dummy test keeps gtest_main linked in.
-TEST(DummyTest, ValueParameterizedTestsAreNotSupportedOnThisPlatform) {}
-
-#endif  // GTEST_HAS_PARAM_TEST
+}  // namespace

--- a/tests/acceptance/googletest-samples/sample8_unittest.cc
+++ b/tests/acceptance/googletest-samples/sample8_unittest.cc
@@ -26,8 +26,7 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Author: vladl@google.com (Vlad Losev)
+
 
 // This sample shows how to test code relying on some global flag variables.
 // Combine() helps with generating all possible combinations of such flags,
@@ -37,8 +36,7 @@
 #include "prime_tables.h"
 
 #include "gtest/gtest.h"
-
-#if GTEST_HAS_COMBINE
+namespace {
 
 // Suppose we want to introduce a new, improved implementation of PrimeTable
 // which combines speed of PrecalcPrimeTable and versatility of
@@ -51,24 +49,25 @@ class HybridPrimeTable : public PrimeTable {
  public:
   HybridPrimeTable(bool force_on_the_fly, int max_precalculated)
       : on_the_fly_impl_(new OnTheFlyPrimeTable),
-        precalc_impl_(force_on_the_fly ? NULL :
-                          new PreCalculatedPrimeTable(max_precalculated)),
+        precalc_impl_(force_on_the_fly
+                          ? nullptr
+                          : new PreCalculatedPrimeTable(max_precalculated)),
         max_precalculated_(max_precalculated) {}
-  virtual ~HybridPrimeTable() {
+  ~HybridPrimeTable() override {
     delete on_the_fly_impl_;
     delete precalc_impl_;
   }
 
-  virtual bool IsPrime(int n) const {
-    if (precalc_impl_ != NULL && n < max_precalculated_)
+  bool IsPrime(int n) const override {
+    if (precalc_impl_ != nullptr && n < max_precalculated_)
       return precalc_impl_->IsPrime(n);
     else
       return on_the_fly_impl_->IsPrime(n);
   }
 
-  virtual int GetNextPrime(int p) const {
+  int GetNextPrime(int p) const override {
     int next_prime = -1;
-    if (precalc_impl_ != NULL && p < max_precalculated_)
+    if (precalc_impl_ != nullptr && p < max_precalculated_)
       next_prime = precalc_impl_->GetNextPrime(p);
 
     return next_prime != -1 ? next_prime : on_the_fly_impl_->GetNextPrime(p);
@@ -90,24 +89,17 @@ using ::testing::Combine;
 // PreCalculatedPrimeTable disabled. We do this by defining fixture which will
 // accept different combinations of parameters for instantiating a
 // HybridPrimeTable instance.
-class PrimeTableTest : public TestWithParam< ::std::tr1::tuple<bool, int> > {
+class PrimeTableTest : public TestWithParam< ::std::tuple<bool, int> > {
  protected:
-  virtual void SetUp() {
-    // This can be written as
-    //
-    // bool force_on_the_fly;
-    // int max_precalculated;
-    // tie(force_on_the_fly, max_precalculated) = GetParam();
-    //
-    // once the Google C++ Style Guide allows use of ::std::tr1::tie.
-    //
-    bool force_on_the_fly = ::std::tr1::get<0>(GetParam());
-    int max_precalculated = ::std::tr1::get<1>(GetParam());
+  void SetUp() override {
+    bool force_on_the_fly;
+    int max_precalculated;
+    std::tie(force_on_the_fly, max_precalculated) = GetParam();
     table_ = new HybridPrimeTable(force_on_the_fly, max_precalculated);
   }
-  virtual void TearDown() {
+  void TearDown() override {
     delete table_;
-    table_ = NULL;
+    table_ = nullptr;
   }
   HybridPrimeTable* table_;
 };
@@ -156,18 +148,7 @@ TEST_P(PrimeTableTest, CanGetNextPrime) {
 // will put some of the tested numbers beyond the capability of the
 // PrecalcPrimeTable instance and some inside it (10). Combine will produce all
 // possible combinations.
-INSTANTIATE_TEST_CASE_P(MeaningfulTestParameters,
-                        PrimeTableTest,
-                        Combine(Bool(), Values(1, 10)));
+INSTANTIATE_TEST_SUITE_P(MeaningfulTestParameters, PrimeTableTest,
+                         Combine(Bool(), Values(1, 10)));
 
-#else
-
-// Google Test may not support Combine() with some compilers. If we
-// use conditional compilation to compile out all code referring to
-// the gtest_main library, MSVC linker will not link that library at
-// all and consequently complain about missing entry point defined in
-// that library (fatal error LNK1561: entry point must be
-// defined). This dummy test keeps gtest_main linked in.
-TEST(DummyTest, CombineIsNotSupportedOnThisPlatform) {}
-
-#endif  // GTEST_HAS_COMBINE
+}  // namespace

--- a/tests/acceptance/googletest-samples/sample9_unittest.cc
+++ b/tests/acceptance/googletest-samples/sample9_unittest.cc
@@ -25,8 +25,7 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Author: vladl@google.com (Vlad Losev)
+
 
 // This sample shows how to use Google Test listener API to implement
 // an alternative console output and how to use the UnitTest reflection API
@@ -44,24 +43,22 @@ using ::testing::TestEventListeners;
 using ::testing::TestInfo;
 using ::testing::TestPartResult;
 using ::testing::UnitTest;
-
 namespace {
-
 // Provides alternative output mode which produces minimal amount of
 // information about tests.
 class TersePrinter : public EmptyTestEventListener {
  private:
   // Called before any test activity starts.
-  virtual void OnTestProgramStart(const UnitTest& /* unit_test */) {}
+  void OnTestProgramStart(const UnitTest& /* unit_test */) override {}
 
   // Called after all test activities have ended.
-  virtual void OnTestProgramEnd(const UnitTest& unit_test) {
+  void OnTestProgramEnd(const UnitTest& unit_test) override {
     fprintf(stdout, "TEST %s\n", unit_test.Passed() ? "PASSED" : "FAILED");
     fflush(stdout);
   }
 
   // Called before a test starts.
-  virtual void OnTestStart(const TestInfo& test_info) {
+  void OnTestStart(const TestInfo& test_info) override {
     fprintf(stdout,
             "*** Test %s.%s starting.\n",
             test_info.test_case_name(),
@@ -70,7 +67,7 @@ class TersePrinter : public EmptyTestEventListener {
   }
 
   // Called after a failed assertion or a SUCCEED() invocation.
-  virtual void OnTestPartResult(const TestPartResult& test_part_result) {
+  void OnTestPartResult(const TestPartResult& test_part_result) override {
     fprintf(stdout,
             "%s in %s:%d\n%s\n",
             test_part_result.failed() ? "*** Failure" : "Success",
@@ -81,7 +78,7 @@ class TersePrinter : public EmptyTestEventListener {
   }
 
   // Called after a test ends.
-  virtual void OnTestEnd(const TestInfo& test_info) {
+  void OnTestEnd(const TestInfo& test_info) override {
     fprintf(stdout,
             "*** Test %s.%s ending.\n",
             test_info.test_case_name(),
@@ -102,7 +99,6 @@ TEST(CustomOutputTest, Fails) {
   EXPECT_EQ(1, 2)
       << "This test fails in order to demonstrate alternative failure messages";
 }
-
 }  // namespace
 
 int main(int argc, char **argv) {
@@ -139,10 +135,10 @@ int main(int argc, char **argv) {
   // This is an example of using the UnitTest reflection API to inspect test
   // results. Here we discount failures from the tests we expected to fail.
   int unexpectedly_failed_tests = 0;
-  for (int i = 0; i < unit_test.total_test_case_count(); ++i) {
-    const TestCase& test_case = *unit_test.GetTestCase(i);
-    for (int j = 0; j < test_case.total_test_count(); ++j) {
-      const TestInfo& test_info = *test_case.GetTestInfo(j);
+  for (int i = 0; i < unit_test.total_test_suite_count(); ++i) {
+    const testing::TestSuite& test_suite = *unit_test.GetTestSuite(i);
+    for (int j = 0; j < test_suite.total_test_count(); ++j) {
+      const TestInfo& test_info = *test_suite.GetTestInfo(j);
       // Counts failed tests that were not meant to fail (those without
       // 'Fails' in the name).
       if (test_info.result()->Failed() &&

--- a/tests/gtest.cpp
+++ b/tests/gtest.cpp
@@ -30,6 +30,17 @@ TEST_F(FooTest, DISABLED_test_disabled) {
   EXPECT_EQ(2 * 6, 10);
 }
 
+// Tests that the Foo::Bar() method does Abc.
+TEST_F(FooTest, test_skipped) {
+  GTEST_SKIP() << "This is a skipped message";
+  EXPECT_EQ(true, false);
+}
+
+// Tests that the Foo::Bar() method does Abc.
+TEST_F(FooTest, test_skipped_no_msg) {
+  GTEST_SKIP();
+  EXPECT_EQ(true, false);
+}
 
 }  // namespace
 

--- a/tests/test_pytest_cpp.py
+++ b/tests/test_pytest_cpp.py
@@ -95,18 +95,18 @@ def test_google_failure(exes):
     assert len(failures) == 2
     colors = ("red", "bold")
     assert failures[0].get_lines() == [
-        ('Expected equality of these values:', colors),
-        ('  2 * 3', colors),
-        ('    Which is: 6', colors),
-        ('  5', colors)
+        ("Expected equality of these values:", colors),
+        ("  2 * 3", colors),
+        ("    Which is: 6", colors),
+        ("  5", colors),
     ]
     assert failures[0].get_file_reference() == ("gtest.cpp", 19)
 
     assert failures[1].get_lines() == [
-        ('Expected equality of these values:', colors),
-        ('  2 * 6', colors),
-        ('    Which is: 12', colors),
-        ('  15', colors),
+        ("Expected equality of these values:", colors),
+        ("  2 * 6", colors),
+        ("    Which is: 12", colors),
+        ("  15", colors),
     ]
     assert failures[1].get_file_reference() == ("gtest.cpp", 20)
 

--- a/tests/test_pytest_cpp.py
+++ b/tests/test_pytest_cpp.py
@@ -47,6 +47,8 @@ def dummy_failure():
                 "FooTest.test_failure",
                 "FooTest.test_error",
                 "FooTest.DISABLED_test_disabled",
+                "FooTest.test_skipped",
+                "FooTest.test_skipped_no_msg",
             ],
         ),
         (BoostTestFacade(), "boost_success", ["boost_success"]),
@@ -93,16 +95,18 @@ def test_google_failure(exes):
     assert len(failures) == 2
     colors = ("red", "bold")
     assert failures[0].get_lines() == [
-        ("      Expected: 2 * 3", colors),
-        ("      Which is: 6", colors),
-        ("To be equal to: 5", colors),
+        ('Expected equality of these values:', colors),
+        ('  2 * 3', colors),
+        ('    Which is: 6', colors),
+        ('  5', colors)
     ]
     assert failures[0].get_file_reference() == ("gtest.cpp", 19)
 
     assert failures[1].get_lines() == [
-        ("      Expected: 2 * 6", colors),
-        ("      Which is: 12", colors),
-        ("To be equal to: 15", colors),
+        ('Expected equality of these values:', colors),
+        ('  2 * 6', colors),
+        ('    Which is: 12', colors),
+        ('  15', colors),
     ]
     assert failures[1].get_file_reference() == ("gtest.cpp", 20)
 
@@ -124,8 +128,26 @@ def test_google_error(exes):
 
 def test_google_disabled(exes):
     facade = GoogleTestFacade()
-    with pytest.raises(pytest.skip.Exception):
+    try:
         facade.run_test(exes.get("gtest"), "FooTest.DISABLED_test_disabled")
+    except pytest.skip.Exception as disabled_message:
+        assert "Disabled" in str(disabled_message)
+
+
+def test_google_skipped(exes):
+    facade = GoogleTestFacade()
+    try:
+        facade.run_test(exes.get("gtest"), "FooTest.test_skipped")
+        assert False, "No skipped exception found"
+    except pytest.skip.Exception as skipped_message:
+        assert "This is a skipped message" in str(skipped_message)
+
+
+def test_google_skipped_no_msg(exes):
+    facade = GoogleTestFacade()
+    with pytest.raises(pytest.skip.Exception):
+        facade.run_test(exes.get("gtest"), "FooTest.test_skipped_no_msg")
+        assert False, "No skipped exception found"
 
 
 def test_boost_failure(exes):
@@ -191,6 +213,8 @@ def test_google_run(testdir, exes):
             ("FooTest.test_failure", "failed"),
             ("FooTest.test_error", "failed"),
             ("FooTest.DISABLED_test_disabled", "skipped"),
+            ("FooTest.test_skipped", "skipped"),
+            ("FooTest.test_skipped_no_msg", "skipped"),
         ],
     )
 


### PR DESCRIPTION
This change will include the gtest skipped message into the result.xml output file. This PR is solving issue: https://github.com/pytest-dev/pytest-cpp/issues/69