### PR TITLE
Catch2: handle exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # UNRELEASED
 
 - Catch2: add support for catch version 3 ([#115](https://github.com/pytest-dev/pytest-cpp/pull/115))
+- Catch2: support exception handling ([#117](https://github.com/pytest-dev/pytest-cpp/pull/117))
 
 # 2.4.0 (2023-09-08)
 

--- a/src/pytest_cpp/catch2.py
+++ b/src/pytest_cpp/catch2.py
@@ -191,6 +191,19 @@ class Catch2Facade(AbstractFacade):
                                     fail_msg,
                                 )
                             )
+                    test_exception = test_case.findall(".//Exception")
+                    for exception in test_exception:
+                        file_name = exception.attrib["filename"]
+                        line_num = int(exception.attrib["line"])
+
+                        fail_msg = f"Error: {exception.text}"
+                        failures.append(
+                            (
+                                file_name,
+                                line_num,
+                                fail_msg,
+                            )
+                        )
                 skipped = False  # TODO: skipped tests don't appear in the results
                 result.append((test_name, failures, skipped))
 

--- a/tests/SConstruct
+++ b/tests/SConstruct
@@ -46,9 +46,11 @@ for filename in boost_files:
 for env, label in [(c3env, "_v3"), (c2env, "")]:
     catch2_success = env.Object(f'catch2_success{label}', 'catch2_success.cpp')
     catch2_failure = env.Object(f'catch2_failure{label}', 'catch2_failure.cpp')
+    catch2_error = env.Object(f'catch2_error{label}', 'catch2_error.cpp')
 
     env.Program(catch2_success)
     env.Program(catch2_failure)
+    env.Program(catch2_error)
 
 SConscript('acceptance/googletest-samples/SConscript')
 SConscript('acceptance/boosttest-samples/SConscript')

--- a/tests/catch2_error.cpp
+++ b/tests/catch2_error.cpp
@@ -1,0 +1,10 @@
+#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
+#include "catch.hpp"
+
+#include <stdexcept>
+
+
+TEST_CASE( "Error" ) {
+    throw std::runtime_error("a runtime error");
+    REQUIRE(true);
+}

--- a/tests/test_pytest_cpp.py
+++ b/tests/test_pytest_cpp.py
@@ -629,9 +629,7 @@ def test_catch2_failure(exes):
         assert len(failures) == 2
 
         # test exceptions
-        failures, _ = facade.run_test(
-            exes.get(f"catch2_error{suffix}"), "Error"
-        )
+        failures, _ = facade.run_test(exes.get(f"catch2_error{suffix}"), "Error")
         assert len(failures) == 1
 
 

--- a/tests/test_pytest_cpp.py
+++ b/tests/test_pytest_cpp.py
@@ -628,6 +628,12 @@ def test_catch2_failure(exes):
         )
         assert len(failures) == 2
 
+        # test exceptions
+        failures, _ = facade.run_test(
+            exes.get(f"catch2_error{suffix}"), "Error"
+        )
+        assert len(failures) == 1
+
 
 class TestError:
     def test_get_whitespace(self):

--- a/tests/test_pytest_cpp.py
+++ b/tests/test_pytest_cpp.py
@@ -630,9 +630,7 @@ def test_catch2_failure(exes):
 
         # test exceptions
         failures, _ = facade.run_test(exes.get(f"catch2_error{suffix}"), "Error")
-        assert len(failures) == 1
-
-        fail1 = failures[0]
+        [fail1] = failures
         assert_catch2_failure(fail1.get_lines()[0], "Error: ", colors)
         assert_catch2_failure(fail1.get_lines()[1], "a runtime error", colors)
 

--- a/tests/test_pytest_cpp.py
+++ b/tests/test_pytest_cpp.py
@@ -632,6 +632,10 @@ def test_catch2_failure(exes):
         failures, _ = facade.run_test(exes.get(f"catch2_error{suffix}"), "Error")
         assert len(failures) == 1
 
+        fail1 = failures[0]
+        assert_catch2_failure(fail1.get_lines()[0], "Error: ", colors)
+        assert_catch2_failure(fail1.get_lines()[1], "a runtime error", colors)
+
 
 class TestError:
     def test_get_whitespace(self):


### PR DESCRIPTION
Exceptions are a separate output in the XML from normal failures