### PR TITLE
Escape special characters in Catch2 test names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # UNRELEASED
 
-- Catch2: add support for catch version 3 ([#115](https://github.com/pytest-dev/pytest-cpp/pull/115))
-- Catch2: support exception handling ([#117](https://github.com/pytest-dev/pytest-cpp/pull/117))
+- Catch2: add support for catch version 3 ([#115](https://github.com/pytest-dev/pytest-cpp/pull/115)).
+- Catch2: support exception handling ([#117](https://github.com/pytest-dev/pytest-cpp/pull/117)).
+- Catch2: Correctly handle test names that contain special characters ([#123](https://github.com/pytest-dev/pytest-cpp/issues/123)).
 - Added support for Python 3.12.
 
 # 2.4.0 (2023-09-08)

--- a/src/pytest_cpp/catch2.py
+++ b/src/pytest_cpp/catch2.py
@@ -21,7 +21,7 @@ _special_chars_map: dict[int, str] = {i: "\\" + chr(i) for i in b'[]*,~\\"'}
 
 
 def escape(test_id: str) -> str:
-    """Escape special characters in test names."""
+    """Escape special characters in test names (see #123)."""
     return test_id.translate(_special_chars_map)
 
 

--- a/tests/SConstruct
+++ b/tests/SConstruct
@@ -47,10 +47,15 @@ for env, label in [(c3env, "_v3"), (c2env, "")]:
     catch2_success = env.Object(f'catch2_success{label}', 'catch2_success.cpp')
     catch2_failure = env.Object(f'catch2_failure{label}', 'catch2_failure.cpp')
     catch2_error = env.Object(f'catch2_error{label}', 'catch2_error.cpp')
+    catch2_special_chars = env.Object(
+        f'catch2_special_chars{label}',
+        'catch2_special_chars.cpp'
+    )
 
     env.Program(catch2_success)
     env.Program(catch2_failure)
     env.Program(catch2_error)
+    env.Program(catch2_special_chars)
 
 SConscript('acceptance/googletest-samples/SConscript')
 SConscript('acceptance/boosttest-samples/SConscript')

--- a/tests/catch2_special_chars.cpp
+++ b/tests/catch2_special_chars.cpp
@@ -1,0 +1,26 @@
+#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
+#include "catch.hpp"
+
+TEST_CASE( "Brackets in [test] name" ) {
+    REQUIRE( true );
+}
+
+TEST_CASE( "**Star in test name**" ) {
+    REQUIRE( true );
+}
+
+TEST_CASE( "~Tilde in test name" ) {
+    REQUIRE( true );
+}
+
+TEST_CASE( "Comma, in, test, name" ) {
+    REQUIRE( true );
+}
+
+TEST_CASE( R"(Backslash\ in\ test\ name)" ) {
+    REQUIRE( true );
+}
+
+TEST_CASE( "\"Quotes\" in test name" ) {
+    REQUIRE( true );
+}

--- a/tests/test_pytest_cpp.py
+++ b/tests/test_pytest_cpp.py
@@ -635,6 +635,24 @@ def test_catch2_failure(exes):
         assert_catch2_failure(fail1.get_lines()[1], "a runtime error", colors)
 
 
+@pytest.mark.parametrize("suffix", ["", "_v3"])
+@pytest.mark.parametrize(
+    "test_id",
+    [
+        "Brackets in [test] name",
+        "**Star in test name**",
+        "~Tilde in test name",
+        "Comma, in, test, name",
+        r"Backslash\ in\ test\ name",
+        '"Quotes" in test name',
+    ],
+)
+def test_catch2_special_chars(suffix, test_id, exes):
+    facade = Catch2Facade()
+    exe = exes.get("catch2_special_chars" + suffix)
+    assert facade.run_test(exe, test_id)[0] is None
+
+
 class TestError:
     def test_get_whitespace(self):
         assert error.get_left_whitespace("  foo") == "  "


### PR DESCRIPTION
Fixes #123

When running a given Catch2 test, escape any special characters in the test name. Special characters include `[]*,~\"`.
