### PR TITLE
consider catch2's FAIL()

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,10 +16,10 @@ jobs:
       SETUPTOOLS_SCM_PRETEND_VERSION: ${{ github.event.inputs.version }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.7
 
     - name: Build and Check Package
-      uses: hynek/build-and-inspect-python-package@v1.5
+      uses: hynek/build-and-inspect-python-package@v2.9.0
 
   deploy:
     needs: package
@@ -30,10 +30,10 @@ jobs:
       contents: write  # For tag and release notes.
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.7
 
     - name: Download Package
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4.1.8
       with:
         name: Packages
         path: dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
           pip install scons
           scons -j4 -C tests
       - name: Upload compilation results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: tests
           if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,9 @@ jobs:
         gtest_ver: [ "1.11.0" ]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4.1.7
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: "3.8"
       - name: Install GoogleTest
@@ -64,9 +64,9 @@ jobs:
   package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.7
       - name: Build and Check Package
-        uses: hynek/build-and-inspect-python-package@v1.5
+        uses: hynek/build-and-inspect-python-package@v2.9.0
 
   test:
     needs: [compile, package]
@@ -78,20 +78,20 @@ jobs:
         python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4.1.7
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5.2.0
       with:
         python-version: ${{ matrix.python }}
 
     - name: Download compiled tests
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4.1.8
       with:
         name: tests
         path: tests
 
     - name: Download Package
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4.1.8
       with:
         name: Packages
         path: dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# UNRELEASED
+
+- Catch2: recognize `FAIL()` calls ([#147](https://github.com/pytest-dev/pytest-cpp/pull/147)).
+
 # 2.5.0 (2023-11-01)
 
 - Catch2: add support for catch version 3 ([#115](https://github.com/pytest-dev/pytest-cpp/pull/115)).

--- a/src/pytest_cpp/catch2.py
+++ b/src/pytest_cpp/catch2.py
@@ -198,6 +198,7 @@ class Catch2Facade(AbstractFacade):
                                     fail_msg,
                                 )
                             )
+                    # These two tags contain the same attributes and can be treated the same
                     test_exception = test_case.findall(".//Exception")
                     test_failure = test_case.findall(".//Failure")
                     for exception in test_exception + test_failure:

--- a/src/pytest_cpp/catch2.py
+++ b/src/pytest_cpp/catch2.py
@@ -199,11 +199,12 @@ class Catch2Facade(AbstractFacade):
                                 )
                             )
                     test_exception = test_case.findall(".//Exception")
-                    for exception in test_exception:
+                    test_failure = test_case.findall(".//Failure")
+                    for exception in (test_exception + test_failure):
                         file_name = exception.attrib["filename"]
                         line_num = int(exception.attrib["line"])
 
-                        fail_msg = f"Error: {exception.text}"
+                        fail_msg = f"Error: {exception.text.strip()}"
                         failures.append(
                             (
                                 file_name,

--- a/src/pytest_cpp/catch2.py
+++ b/src/pytest_cpp/catch2.py
@@ -200,7 +200,7 @@ class Catch2Facade(AbstractFacade):
                             )
                     test_exception = test_case.findall(".//Exception")
                     test_failure = test_case.findall(".//Failure")
-                    for exception in (test_exception + test_failure):
+                    for exception in test_exception + test_failure:
                         file_name = exception.attrib["filename"]
                         line_num = int(exception.attrib["line"])
 

--- a/src/pytest_cpp/catch2.py
+++ b/src/pytest_cpp/catch2.py
@@ -204,7 +204,7 @@ class Catch2Facade(AbstractFacade):
                         file_name = exception.attrib["filename"]
                         line_num = int(exception.attrib["line"])
 
-                        fail_msg = f"Error: {exception.text.strip()}"
+                        fail_msg = f"Error: {exception.text}"
                         failures.append(
                             (
                                 file_name,

--- a/tests/catch2_failure.cpp
+++ b/tests/catch2_failure.cpp
@@ -13,6 +13,10 @@ TEST_CASE( "Factorials are computed", "[factorial]" ) {
     REQUIRE( Factorial(10) == 3628800 );
 }
 
+TEST_CASE( "Test fail macro" ) {
+    FAIL("This is a fail");
+}
+
 TEST_CASE( "Failed Sections" ) {
     SECTION( "failed 1" ) {
         REQUIRE(false);


### PR DESCRIPTION
I believe FAIL_CHECK also produces a `Failure` tag

https://github.com/catchorg/Catch2/blob/fa43b77429ba76c462b1898d6cd2f2d7a9416b14/docs/logging.md?plain=1#L119-L125

This wasn't being marked as a failure with pytest, now it is:

code:

```c++
void checkWidgetTrWrap(MainWindow &w) {
  for (auto widget : w.findChildren<T>()) {
  const QString text = widget->text();
    bool isNumber = RE_NUM.exactMatch(text);
    bool wrapped = text.contains(TEST_TEXT);
    QString parentWidgets = getParentWidgets(widget).join("->");

    if (!text.isEmpty() && !isNumber && !wrapped) {
      FAIL(("\"" + text + "\" must be wrapped. Parent widgets: " + parentWidgets).toStdString());
    }

    // warn if source string wrapped, but UI adds text
    // TODO: add way to ignore this
    if (wrapped && text != TEST_TEXT) {
      WARN(("\"" + text + "\" is dynamic and needs a custom retranslate function. Parent widgets: " + parentWidgets).toStdString());
    }
  }
}
```

output:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<Catch name="test_translations">
  <Group name="test_translations">
    <TestCase name="UI: test all strings wrapped" filename="selfdrive/ui/tests/test_translations.cc" line="39">
      <Failure filename="selfdrive/ui/tests/test_translations.cc" line="27">
        "Disengage on Accelerator Pedal" must be wrapped. Parent widgets: ParamControl->TogglesPanel->QWidget->ScrollView->QStackedWidget->SettingsWindow->MainWindow
      </Failure>
      <OverallResult success="false"/>
    </TestCase>
    <OverallResults successes="0" failures="1" expectedFailures="0"/>
    <OverallResultsCases successes="0" failures="1" expectedFailures="0"/>
  </Group>
  <OverallResults successes="0" failures="1" expectedFailures="0"/>
  <OverallResultsCases successes="0" failures="1" expectedFailures="0"/>
</Catch>
```