### PR TITLE
support for running on remote targets

### DIFF
--- a/src/pytest_cpp/facade_abc.py
+++ b/src/pytest_cpp/facade_abc.py
@@ -32,6 +32,7 @@ class AbstractFacade(ABC):
         test_id: str,
         test_args: Sequence[str] = (),
         harness: Sequence[str] = (),
+        deployed: bool = False,
     ) -> tuple[Sequence[CppTestFailure] | None, str]:
         """
         Runs a test and returns the results.


### PR DESCRIPTION
pytest-cpp supports running tests for different targets only for locally running emulators. This PR adds support for deploying the test to cpp_deploy_path on the remote target using cpp_deploy_cmd.